### PR TITLE
Add ability to abort jobs, add edit mode

### DIFF
--- a/src/components/confirmModal.svelte
+++ b/src/components/confirmModal.svelte
@@ -8,7 +8,7 @@ let waitingForPromise = false;
 
 export let open = false;
 export let action: () => Promise<BackendResponse>;
-export let response: BackendResponse | null;
+export let response: BackendResponse | null = null;
 
 async function submitAction(): Promise<void> {
 	waitingForPromise = true;

--- a/src/routes/JobList.svelte
+++ b/src/routes/JobList.svelte
@@ -14,6 +14,7 @@ import {
 	TableHead,
 	TableHeadCell,
 	TableSearch,
+	Tooltip,
 } from "flowbite-svelte";
 import type { LinkType } from "flowbite-svelte";
 import {
@@ -569,6 +570,7 @@ $: {
                     <Button pill outline class="!p-2" size="xs" color="alternative" on:click={() => openAbortModal(selectedItems)} disabled={selectedAbortButtonDisabled}>
                       <StopSolid class="inline mr-1" color="red"/> {selectedItems.length}
                     </Button>
+                    <Tooltip color="red">Abort selected jobs</Tooltip>
                     <Button pill outline class="!p-2" size="xs" color="alternative" on:click={() => tableEditMode = false}>
                       <CloseOutline/>
                     </Button>
@@ -623,6 +625,7 @@ $: {
 
                           <StopSolid color="red"/>
                         </Button>
+                        <Tooltip color="red">Abort this job</Tooltip>
                       {/if}
                       {#if (["success", "downloaded"].includes(item.status.step))}
                         <Button pill outline class="!p-2" size="xs" color="alternative" on:click={(e) => {e.stopPropagation(); downloadTranscript(item);}} disabled={jobDownloading[item.ID]}>
@@ -632,6 +635,7 @@ $: {
                             <DownloadSolid/>
                           {/if}
                         </Button>
+                        <Tooltip color="green">Download finished transcript</Tooltip>
                       {/if}
                     </ButtonGroup>
                   </TableBodyCell>

--- a/src/utils/httpRequests.ts
+++ b/src/utils/httpRequests.ts
@@ -12,6 +12,7 @@ export type ErrorType =
 
 export type JobStep =
 	| "notReported" //this is not an actual step returned by the backend but a value that I internally assign if the backend doesn't return anything
+	| "aborting" //this also only exists internally and is used to show an animation while the backend aborts a job
 	| "failed"
 	| "notQueued"
 	| "pendingRunner"


### PR DESCRIPTION
This PR finally adds the ability to abort running jobs, either one by one or in bulk. It also includes an edit mode for the job table to do this (and other actions in the future) in bulk for many jobs at once, and some UI polishing.

Partially implements #7